### PR TITLE
Add `protocol-buffers-encodings` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "https://github.com/andrewosh/hyperdrive-schemas/issues"
   },
   "homepage": "https://github.com/andrewosh/hyperdrive-schemas#readme",
+  "dependencies": {
+    "protocol-buffers-encodings": "^1.1.0"
+  },
   "devDependencies": {
     "protocol-buffers": "^4.1.0"
   }


### PR DESCRIPTION
I noticed this missing dependency when importing `hyperdrive-daemon-client` in a standalone project, without any other `dat`-related dependencies. This should solve the issue. 